### PR TITLE
Update about page and restore tagline on home page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,10 @@
         </div>
       </nav>
 
+      {% if page.url == "/" %}
+      <p class="site-tagline">{{ site.tagline }}</p>
+      {% endif %}
+
       {{ content }}
 
       <footer class="site-footer">

--- a/about.md
+++ b/about.md
@@ -3,40 +3,38 @@ layout: page
 title: About
 ---
 
-There's a specific feeling I'm chasing with this blog: the moment a confusing thing suddenly makes sense. Not the textbook version of the concept — the messy, actual process of being wrong, then less wrong, then occasionally right.
+There's a specific feeling I'm chasing with this blog: the moment a confusing thing suddenly makes sense. Not the textbook version of the concept. The messy, actual process of being wrong, then less wrong, then occasionally right.
 
-I'm Nishanth. I've spent a decade building ML systems — fintech, aviation analytics, consulting — and I'm still regularly confused by things I feel I should understand by now. This blog is where I work through that.
-
-The tagline up top — *"an authentic pursuit to rid the imposter in me"* — is not marketing copy. It's the actual situation.
+I'm Nishanth. I've spent a decade building ML systems in fintech, operations, consulting, marketing, engineering, and now insurance — and I'm still regularly confused by things I feel I should understand by now. This blog is where I work through that.
 
 ---
 
 ### What I write here
 
-Short posts about things that confused me, and how I eventually resolved them. Occasionally longer posts walking through experiments and implementations from notebooks.
+Short posts about things that confused me and how I eventually resolved them, or about things I'm intrigued by. Occasionally longer posts walking through experiments and implementations from notebooks.
 
-Most things are ML-adjacent: probability, optimization, neural architectures, MLOps patterns, and whatever I'm currently working through in the [MITx MicroMasters in Statistics and Data Science](https://micromasters.mit.edu/ds/) or OMSCS coursework.
+Most things are ML-adjacent: probability, optimization, neural architectures, MLOps patterns, and whatever I'm currently working through in my OMSCS coursework or just at work.
 
 The approach is Feynman-ish: if I can't explain it clearly, I probably don't understand it yet.
 
-I try to write at the level of someone who knows the domain but hasn't encountered *this specific nuance* — usually me, six months ago.
+I try to write at the level of someone who knows the domain but hasn't encountered this specific nuance — usually me, six months ago.
 
 ---
 
 ### Background
 
-Senior Data Scientist at [Ramboll](https://www.ramboll.com), currently focused on MLOps adoption on Azure.
+Lead Data Scientist at [OIP Insurtech](https://oipinsurtech.com), currently focused on an AI-driven insurance triage product — BoundAI.
 
-Previously: ML frameworks in fintech at scale, NLP-driven contact centre analytics, sustainable aviation fuel modelling.
+Previously: ML frameworks in fintech at scale, NLP-driven contact centre analytics, market research, and more.
 
-Education: MITx MicroMasters in Statistics and Data Science · B.E. in Electrical and Electronics Engineering.
+Education: M.S. in Computer Science at Georgia Tech (OMSCS) · B.E. in Electrical and Electronics Engineering.
 
 ---
 
 ### Outside work
 
-Volunteer with [WWF India](https://www.wwfindia.org) on tiger conservation in the Godavari basin.
-Functional fitness, cycling, backpacking. Read a lot. Play football when I can find eleven people.
+Functional fitness, cycling, backpacking. Read a lot.
+Working through physical rehabilitation post traumatic injuries — swimming is part of the comeback.
 
 ---
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -245,6 +245,19 @@ tbody tr:nth-child(even) td { background: #fafafb; }
 
 
 /* -------------------------
+   Home tagline
+   ------------------------- */
+
+.site-tagline {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-style: italic;
+  margin: -1.75rem 0 2.5rem;   /* pulls up close under the nav border */
+  letter-spacing: 0.01em;
+}
+
+
+/* -------------------------
    Post List (Home)
    ------------------------- */
 


### PR DESCRIPTION
- Rewrite about.md with Nishanth's exact updated content: domains (fintech → ops → consulting → marketing → engineering → insurance), current role as Lead DS at OIP Insurtech on BoundAI, OMSCS (Georgia Tech) replacing MITx MicroMasters, personal section updated (rehab / swimming)
- Add tagline back to home page: renders site.tagline below nav on "/" only
- Add .site-tagline CSS: italic, muted, pulls up close under the nav border