### PR TITLE
Rewrite README to reflect actual blog purpose and workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Copilot Instructions
+
+Guidelines for GitHub Copilot and any AI assistant working in this repository.
+
+## Writing conventions
+
+- **No em-dashes.** Never use the `—` character anywhere in the codebase.
+  Use a hyphen with spaces (` - `), a comma, or a colon depending on context.
+  This applies to all file types: Markdown, HTML, CSS comments, YAML, scripts.
+
+- Keep prose direct and concise. No filler phrases.
+
+## Repository conventions
+
+- **Working branch is `dev`.** All changes go to `dev`.
+  Never commit directly to `main` or `gh-pages`.
+
+## Site structure
+
+- Jekyll static site deployed via GitHub Pages.
+- Layouts in `_layouts/`, styles in `public/css/main.css`, posts in `_posts/`.
+- Short posts come from GitHub Issues. Notebook posts use the automation pipeline
+  in `.github/workflows/convert_notebook_to_markdown.yml`.
+- See `WRITING.md` for the full content and publishing workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Project Instructions
+
+Guidelines for any AI assistant working in this repository.
+
+## Writing conventions
+
+- **No em-dashes.** Never use the `—` character anywhere in the codebase.
+  Use a hyphen with spaces (` - `), a comma, or a colon depending on context.
+  This applies to all file types: Markdown, HTML, CSS comments, YAML, scripts.
+
+- Keep prose direct and concise. No filler phrases.
+
+## Repository conventions
+
+- **Working branch is `dev`.** All changes go to `dev`.
+  Never commit directly to `main` or `gh-pages` - those are deployed by GitHub Pages.
+
+- The working directory for this project is `C:/Users/nisha/Documents/portfolio-dev`.
+  The original clone at `Education & Learning/GitHub/nishzsche.github.io` has a corrupt
+  git object database and should not be used.
+
+## Site structure
+
+- Jekyll static site, deployed via GitHub Pages.
+- Layouts: `_layouts/` · Styles: `public/css/main.css` · Published posts: `_posts/`
+- Short posts originate from GitHub Issues. Notebook posts come through the automation
+  pipeline in `.github/workflows/convert_notebook_to_markdown.yml`.
+- See `WRITING.md` for the full content and publishing workflow.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Short posts about things that confused me and how I eventually resolved them. Oc
 
 - **Generator:** [Jekyll](https://jekyllrb.com) via [GitHub Pages](https://pages.github.com)
 - **Branch structure:** `dev` → working branch (all changes go here) · `main`/`gh-pages` → deployed by GitHub Pages
-- **Theme:** Custom — no third-party theme dependency. Layouts in `_layouts/`, styles in `public/css/main.css`
+- **Theme:** Custom - no third-party theme dependency. Layouts in `_layouts/`, styles in `public/css/main.css`
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -1,58 +1,77 @@
-Welcome to my portfolio! This website showcases various data science projects I’ve worked on throughout my career, featuring hands-on experience in machine learning, natural language processing, data visualization, and predictive analytics. You can explore my work on machine learning models, data processing pipelines, and MLOps deployment, along with detailed case studies and code samples.
+# Learning Curve
 
-## Table of Contents
+> *An authentic pursuit to rid the imposter in me.*
 
-- [About Me](#about-me)
-- [Projects](#projects)
-- [Skills & Expertise](#skills--expertise)
-- [Blog](#blog)
-- [Contact](#contact)
+A personal ML learning blog by [Nishanth Rajamani](https://nishzsche.github.io/about).
 
-## About Me
+Short posts about things that confused me and how I eventually resolved them. Occasionally longer posts walking through experiments and implementations. The approach is Feynman-ish: if I can't explain it clearly, I probably don't understand it yet.
 
-I am Nishanth Rajamani, a Senior Data Scientist with expertise in Machine Learning, NLP, MLOps, and cloud ecosystems like AWS and Azure. My experience spans across domains like risk management, fraud detection, and customer interaction optimization. I am passionate about driving data-driven insights and deploying scalable AI solutions. You can learn more about me on my [LinkedIn](https://www.linkedin.com/in/nishanthrajamani/) or [Twitter](https://x.com/nishzsche).
-
-## Projects
-
-Here are some highlighted projects from my portfolio:
-
-### 1. **Digital Filter Variables for Fraud Detection**
-   - Built and deployed a machine learning pipeline to detect fraudulent transactions in real-time.
-   - Stack: Python, Scikit-learn, Azure ML, ADF, Flask API.
-   - [Project Details](https://github.com/username/fraud-detection)
-
-### 2. **NLP-based call center analytics**
-   - Led a project leveraging NLP techniques to enhance customer interactions and response time.
-   - Stack: Python, NLTK, SpaCy, AWS Sagemaker.
-   - [Project Details](https://github.com/username/customer-interaction-nlp)
-
-### 3. **MLOps Package for Automated Model Deployment**
-   - Developed an MLOps package for automated model versioning and deployment in AWS.
-   - Stack: AWS, Docker, Terraform, Jenkins.
-   - [Project Details](https://github.com/username/mlops-package)
-
-## Skills & Expertise
-
-- **Programming Languages**: Python, R, SQL, Bash
-- **Machine Learning**: Regression, Classification, NLP, Time Series Analysis
-- **Cloud**: AWS, Azure, GCP (with focus on Azure ML, ADF)
-- **MLOps**: Model Deployment, CI/CD, Docker, Kubernetes
-- **Tools**: Scikit-learn, TensorFlow, PyTorch, Flask, Jenkins, Docker, Terraform
-
-## Blog
-
-I also write about my experiences and share insights on data science and machine learning. Check out my latest posts:
-
-
-## Contact
-
-Feel free to reach out to me for any collaborations or inquiries:
-
-- Email: [nishanthrajamani@gmail.com](mailto:nishanthrajamani@gmail.com)
-- LinkedIn: [Nishanth Rajamani](https://www.linkedin.com/in/nishanthrajamani/)
+**Live site:** [nishzsche.github.io](https://nishzsche.github.io)
 
 ---
 
-## License
+## Technical setup
 
-This portfolio is open source and available under the [MIT License](LICENSE).
+- **Generator:** [Jekyll](https://jekyllrb.com) via [GitHub Pages](https://pages.github.com)
+- **Branch structure:** `dev` → working branch (all changes go here) · `main`/`gh-pages` → deployed by GitHub Pages
+- **Theme:** Custom — no third-party theme dependency. Layouts in `_layouts/`, styles in `public/css/main.css`
+
+## Running locally
+
+```bash
+# From the repo root (dev branch)
+bundle install
+bundle exec jekyll serve --drafts
+# → http://localhost:4000
+```
+
+## Publishing workflow
+
+### Short insight posts (phone-first)
+
+1. Feel a confusion → open a **GitHub Issue** with label `confusion`
+2. Fill in the three-move structure in the issue body (see `WRITING.md`)
+3. Iterate in the issue; change label to `drafting`, then `ready`
+4. When ready: copy to `_posts/YYYY-MM-DD-slug.md` → push to `dev` → close issue
+
+### Notebook-derived posts (automated)
+
+1. Write experiment in a Jupyter notebook
+2. Push `.ipynb` to `notebooks/` on `dev`
+3. GitHub Actions (`.github/workflows/convert_notebook_to_markdown.yml`) automatically:
+   - Strips `!pip` / `!conda` install cells
+   - Strips Google Colab boilerplate cells
+   - Converts to Markdown with Jekyll front matter
+   - Derives the post title from the notebook filename
+   - Commits the result to `_posts/`
+
+### Writing guide
+
+See [`WRITING.md`](WRITING.md) for:
+- The three-move post structure with annotated examples
+- The level test ("write to yourself 6 months ago")
+- OMSCS-specific guidance
+- Tag taxonomy
+- Full draft workflow
+
+---
+
+## Repo structure
+
+```
+├── _layouts/          # default, post, page layouts
+├── _includes/         # head.html (meta, OG tags, CSS)
+├── _posts/            # published posts (generated or hand-written)
+├── _drafts/           # notebook staging; short posts live in GitHub Issues
+│   ├── _template.md   # three-move post template
+│   └── INBOX.md       # local confusion capture
+├── notebooks/         # Jupyter notebooks (trigger the automation pipeline)
+├── public/css/        # main.css (custom), syntax.css (Rouge highlighting)
+├── .github/workflows/ # notebook → markdown automation
+├── WRITING.md         # writing guide and draft workflow
+└── _config.yml        # Jekyll configuration
+```
+
+---
+
+MIT License

--- a/WRITING.md
+++ b/WRITING.md
@@ -1,4 +1,4 @@
-# Writing Guide — Learning Curve
+# Writing Guide - Learning Curve
 
 A reference for whenever you're unsure whether to write, what to write, or how to write it.
 Return here when you feel stuck. Most doubts are answered by one of the three moves.
@@ -13,7 +13,7 @@ Every short post is built from exactly three moves. No exceptions.
 
 ### Move 1: The Confusion
 
-State the specific friction point — not the topic, the *precise thing* that didn't make sense.
+State the specific friction point - not the topic, the *precise thing* that didn't make sense.
 
 **Too broad (skip):**
 > I didn't understand KL divergence.
@@ -23,11 +23,11 @@ State the specific friction point — not the topic, the *precise thing* that di
 > would matter *in practice*. It felt like a mathematical footnote.
 
 **Another example:**
-> Batch norm is said to "reduce internal covariate shift" — but I couldn't connect that phrase
+> Batch norm is said to "reduce internal covariate shift" - but I couldn't connect that phrase
 > to why it speeds up training. The words made sense; the mechanism didn't.
 
 **The test:** Could someone with your background read the confusion and immediately know
-exactly what you mean — not just the topic, but the *sticking point*? If yes, it's specific enough.
+exactly what you mean - not just the topic, but the *sticking point*? If yes, it's specific enough.
 
 ---
 
@@ -39,7 +39,7 @@ Write out your wrong mental model. This is often the most valuable part of the p
 Readers who share your wrong model will experience the same "click" you did.
 
 **Example (KL divergence):**
-> I thought the asymmetry was a quirk — like how subtraction isn't commutative.
+> I thought the asymmetry was a quirk - like how subtraction isn't commutative.
 > Interesting mathematically, but no practical consequence.
 > Both directions "measured the same thing," just from different sides.
 
@@ -55,9 +55,9 @@ Readers who share your wrong model will experience the same "click" you did.
 What actually makes sense, and the one sentence you'd say to yourself 6 months ago.
 
 **Example (KL divergence):**
-> KL(P||Q) — where P is the true distribution — heavily penalises places where P is
+> KL(P||Q) - where P is the true distribution - heavily penalises places where P is
 > high but Q is low. You're forced to cover P's mass. KL(Q||P) penalises the reverse.
-> In variational inference, minimising KL(Q||P) lets Q be zero-seeking — it ignores
+> In variational inference, minimising KL(Q||P) lets Q be zero-seeking - it ignores
 > modes of P it can't explain, rather than spreading thin mass across all of them.
 > The direction isn't a quirk. It's a design decision about which errors you prefer to make.
 >
@@ -67,9 +67,9 @@ What actually makes sense, and the one sentence you'd say to yourself 6 months a
 > The scale and shift (γ, β) are learned per-feature. After normalising to mean=0, std=1,
 > the network *re-learns* the optimal scale for each feature. The normalisation step
 > makes the loss landscape smoother; the learnable parameters ensure you don't lose
-> representational power. They're not afterthoughts — they're what keeps the layer useful.
+> representational power. They're not afterthoughts - they're what keeps the layer useful.
 >
-> **Takeaway:** Batch norm's job isn't to fix the scale — it's to make the scale
+> **Takeaway:** Batch norm's job isn't to fix the scale - it's to make the scale
 > learnable from a stable starting point.
 
 ---
@@ -84,8 +84,8 @@ They do need the specific nuance explained clearly.
 
 | Fails the test | Passes the test |
 |---|---|
-| "Gradient descent updates weights to minimise loss" — too basic | "I assumed Adam's β₂ was just variance smoothing, but its interaction with the warmup schedule changes the effective learning rate non-linearly in the first N steps" |
-| "KL divergence measures the difference between two distributions" — too generic | "I thought both KL directions punished the same errors — just from opposite sides" |
+| "Gradient descent updates weights to minimise loss" - too basic | "I assumed Adam's β₂ was just variance smoothing, but its interaction with the warmup schedule changes the effective learning rate non-linearly in the first N steps" |
+| "KL divergence measures the difference between two distributions" - too generic | "I thought both KL directions punished the same errors - just from opposite sides" |
 | A formal definition from a textbook | The specific sentence that made something click |
 
 ---
@@ -95,13 +95,13 @@ They do need the specific nuance explained clearly.
 Ask one question: **Would I have found this useful 6 months ago?**
 
 **High value:**
-- A concept from an OMSCS course the lecture made opaque — and you found the intuition elsewhere
+- A concept from an OMSCS course the lecture made opaque - and you found the intuition elsewhere
 - A library or API that behaves differently from what the docs suggest
 - A result that surprised you, and why the naive expectation was wrong
 - A mental model you held for months that turned out to be subtly incorrect
 
 **Low value:**
-- "Here's how to install X" — documentation, not insight
+- "Here's how to install X" - documentation, not insight
 - A notebook export with no commentary on the surprising parts
 - "Today I learned Y" without the wrong-model → resolution arc
 
@@ -112,13 +112,13 @@ Ask one question: **Would I have found this useful 6 months ago?**
 You're a practitioner doing grad school. That's rare. Honour both sides.
 
 **Do:**
-- Tag posts with course codes (`CS7641`, `CS7642`, `ISYE6501`, etc.) — these are among the most-searched ML phrases
-- Write about where theory and practice diverge — that's your unique angle
+- Tag posts with course codes (`CS7641`, `CS7642`, `ISYE6501`, etc.) - these are among the most-searched ML phrases
+- Write about where theory and practice diverge - that's your unique angle
 - Write about *why* an assignment approach is designed the way it is, not just what it does
 
 **Don't:**
-- Share solutions or code for graded assignments — this violates the honour code
-- Skip the practitioner lens — "here's how this maps to something I've built at work" adds value no student-only blog can
+- Share solutions or code for graded assignments - this violates the honour code
+- Skip the practitioner lens - "here's how this maps to something I've built at work" adds value no student-only blog can
 
 ---
 
@@ -126,7 +126,7 @@ You're a practitioner doing grad school. That's rare. Honour both sides.
 
 | | Notebook post | Short post |
 |---|---|---|
-| **Length** | Long — code + explanation | Short — 200–400 words |
+| **Length** | Long - code + explanation | Short - 200–400 words |
 | **Source** | `notebooks/` → automation pipeline | GitHub Issues → `_posts/` directly |
 | **Best for** | Experiments, data exploration, algorithm comparisons | Conceptual confusions, mental model corrections, OMSCS insights |
 | **Rule of thumb** | The *process* matters (what you tried, what happened) | The *moment* matters (one thing that clicked) |
@@ -139,7 +139,7 @@ You're a practitioner doing grad school. That's rare. Honour both sides.
 
 The trigger is: *resolved confusion → post opportunity*.
 
-With active OMSCS + MITx studying, that's naturally 1–4 short posts a month without forcing anything. A "post every week" commitment produces mediocre posts written just to hit the number. Write when something clicks. The constraint isn't time — it's having the resolution.
+With active OMSCS + MITx studying, that's naturally 1–4 short posts a month without forcing anything. A "post every week" commitment produces mediocre posts written just to hit the number. Write when something clicks. The constraint isn't time - it's having the resolution.
 
 The window matters: write within 48 hours of the moment something clicks. After that, the confusion feels obvious in hindsight and you lose the ability to explain it to someone who's still confused.
 
@@ -157,7 +157,7 @@ GitHub Issue (phone)  →  _posts/ (laptop, when ready)
 
 | Label | Meaning |
 |---|---|
-| `confusion` | Captured — the confusion exists, resolution pending |
+| `confusion` | Captured - the confusion exists, resolution pending |
 | `drafting` | Moves 1 + 2 written, working on resolution |
 | `ready` | All three moves complete, ready to publish |
 
@@ -167,7 +167,7 @@ GitHub Issue (phone)  →  _posts/ (laptop, when ready)
    The issue title = your post's working title.
 
 2. **Draft (phone or laptop):** Fill in Move 1 and Move 2 in the issue body using the template below.
-   Change label to `drafting`. Leave Move 3 blank — that's fine.
+   Change label to `drafting`. Leave Move 3 blank - that's fine.
 
 3. **Iterate:** Add comments to the issue as you think more about it.
    Edit the body as your understanding evolves.
@@ -206,7 +206,7 @@ An issue can sit open for weeks. That's fine. The goal is to **never lose a conf
 
 ## Tag Taxonomy
 
-Use at most 2–3 tags per post. Be consistent — these are how future-you finds things.
+Use at most 2–3 tags per post. Be consistent - these are how future-you finds things.
 
 | Tag | Use for |
 |---|---|
@@ -216,7 +216,7 @@ Use at most 2–3 tags per post. Be consistent — these are how future-you find
 | `deep-learning` | Neural nets, training, architectures |
 | `ml-theory` | Bias-variance, PAC learning, generalisation bounds |
 | `implementation` | Code behaviour, library quirks, debugging |
-| `OMSCS` | Course-specific insights — pair with course code tag |
+| `OMSCS` | Course-specific insights - pair with course code tag |
 | `paper-notes` | Insight from a specific paper |
 | `intuition` | Mental model corrections, "aha" moments |
 | `mlops` | Deployment, pipelines, experiment tracking |

--- a/_drafts/INBOX.md
+++ b/_drafts/INBOX.md
@@ -1,6 +1,6 @@
 # Confusion Inbox
 
-Raw captures. One line per confusion. Don't elaborate here — just log it and move on.
+Raw captures. One line per confusion. Don't elaborate here - just log it and move on.
 Develop into a full draft in `_drafts/` when you have time.
 
 **From your phone:** Open a GitHub Issue with label `confusion`. Process issues into this file weekly.

--- a/_drafts/_template.md
+++ b/_drafts/_template.md
@@ -14,13 +14,13 @@ tags: []
 ## What I Thought Was True
 
 <!-- Your wrong mental model before the resolution.
-     Write it out fully — readers who share your model will get the most from this. -->
+     Write it out fully - readers who share your model will get the most from this. -->
 
 ## The Resolution
 
 <!-- What actually makes sense and why.
      One concrete example or analogy often does more than a formal explanation.
-     Leave this blank until you have it — that's fine. -->
+     Leave this blank until you have it - that's fine. -->
 
 ## The Takeaway
 
@@ -28,4 +28,4 @@ tags: []
 
 ---
 
-*Source: [what helped — paper, course, experiment, person, code]*
+*Source: [what helped - paper, course, experiment, person, code]*

--- a/about.md
+++ b/about.md
@@ -5,7 +5,7 @@ title: About
 
 There's a specific feeling I'm chasing with this blog: the moment a confusing thing suddenly makes sense. Not the textbook version of the concept. The messy, actual process of being wrong, then less wrong, then occasionally right.
 
-I'm Nishanth. I've spent a decade building ML systems in fintech, operations, consulting, marketing, engineering, and now insurance — and I'm still regularly confused by things I feel I should understand by now. This blog is where I work through that.
+I'm Nishanth. I've spent a decade building ML systems in fintech, operations, consulting, marketing, engineering, and now insurance, and I'm still regularly confused by things I feel I should understand by now. This blog is where I work through that.
 
 ---
 
@@ -17,13 +17,13 @@ Most things are ML-adjacent: probability, optimization, neural architectures, ML
 
 The approach is Feynman-ish: if I can't explain it clearly, I probably don't understand it yet.
 
-I try to write at the level of someone who knows the domain but hasn't encountered this specific nuance — usually me, six months ago.
+I try to write at the level of someone who knows the domain but hasn't encountered this specific nuance - usually me, six months ago.
 
 ---
 
 ### Background
 
-Lead Data Scientist at [OIP Insurtech](https://oipinsurtech.com), currently focused on an AI-driven insurance triage product — BoundAI.
+Lead Data Scientist at [OIP Insurtech](https://oipinsurtech.com), currently focused on an AI-driven insurance triage product - BoundAI.
 
 Previously: ML frameworks in fintech at scale, NLP-driven contact centre analytics, market research, and more.
 
@@ -34,7 +34,7 @@ Education: M.S. in Computer Science at Georgia Tech (OMSCS) · B.E. in Electrica
 ### Outside work
 
 Functional fitness, cycling, backpacking. Read a lot.
-Working through physical rehabilitation post traumatic injuries — swimming is part of the comeback.
+Working through physical rehabilitation post traumatic injuries - swimming is part of the comeback.
 
 ---
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,5 +1,5 @@
 /*
- * Learning Curve — main.css
+ * Learning Curve - main.css
  * Option B: sidebar-free, centered column.
  * Palette: warm stone background · violet accent · dark code blocks.
  */
@@ -10,7 +10,7 @@
    ------------------------- */
 
 :root {
-  --bg:           #fafaf9;   /* stone-50 — barely off-white, warm */
+  --bg:           #fafaf9;   /* stone-50 - barely off-white, warm */
   --surface:      #f4f4f5;   /* inline code bg */
   --border:       #e4e4e7;   /* zinc-200 */
   --border-soft:  #f0f0f2;   /* post list divider, very subtle */


### PR DESCRIPTION
- Remove outdated portfolio framing, fake project links, and skills list
- Describe site accurately: Feynman-style ML learning blog
- Add technical setup: Jekyll, GitHub Pages, dev branch structure
- Add local dev instructions (bundle exec jekyll serve --drafts)
- Document both publishing workflows: short posts via GitHub Issues → _posts/ notebooks via GitHub Actions automation pipeline
- Add repo structure overview
- Point to WRITING.md as the writing guide