### PR TITLE
Expand blog scope; add Exploration post format

### DIFF
--- a/WRITING.md
+++ b/WRITING.md
@@ -1,13 +1,25 @@
 # Writing Guide - Learning Curve
 
 A reference for whenever you're unsure whether to write, what to write, or how to write it.
-Return here when you feel stuck. Most doubts are answered by one of the three moves.
+Return here when you feel stuck. There are two post formats: Resolution and Exploration.
 
 ---
 
-## The Three Moves
+## Two Post Formats
 
-Every short post is built from exactly three moves. No exceptions.
+| | Resolution | Exploration |
+|---|---|---|
+| **For** | A confusion you've worked through | A curiosity you're still inside |
+| **Ends with** | A takeaway - one clear sentence | Open questions - genuinely unresolved |
+| **Trigger** | Something clicked | Something has your attention |
+| **Template** | `_drafts/_template.md` | `_drafts/_exploration_template.md` |
+| **Issue label** | `confusion` → `drafting` → `ready` | `exploration` |
+
+---
+
+## Post Format 1: The Resolution
+
+For confusions you've resolved. Three moves, in order.
 
 ---
 
@@ -19,12 +31,13 @@ State the specific friction point - not the topic, the *precise thing* that didn
 > I didn't understand KL divergence.
 
 **Right level:**
-> I understood that KL(P||Q) ≠ KL(Q||P), but I couldn't see why the direction of measurement
+> I understood that KL(P||Q) != KL(Q||P), but I couldn't see why the direction of measurement
 > would matter *in practice*. It felt like a mathematical footnote.
 
-**Another example:**
-> Batch norm is said to "reduce internal covariate shift" - but I couldn't connect that phrase
-> to why it speeds up training. The words made sense; the mechanism didn't.
+**Hobby example:**
+> I understood that wet-on-wet watercolor was supposed to give soft edges.
+> But every time I tried it, the paint bloomed into blotches I didn't intend.
+> I couldn't tell if the problem was the water ratio, the paper, or my timing.
 
 **The test:** Could someone with your background read the confusion and immediately know
 exactly what you mean - not just the topic, but the *sticking point*? If yes, it's specific enough.
@@ -43,10 +56,10 @@ Readers who share your wrong model will experience the same "click" you did.
 > Interesting mathematically, but no practical consequence.
 > Both directions "measured the same thing," just from different sides.
 
-**Example (batch norm):**
-> I thought batch norm normalised activations so the network could train with a higher
-> learning rate without exploding. I was ignoring everything after the normalisation step
-> (the learnable scale and shift parameters). I thought those were just there for "flexibility."
+**Example (watercolors):**
+> I thought wet-on-wet meant: wet the paper, then paint.
+> I was treating the wetness as a fixed state rather than something that changes
+> as the paper dries - so my timing was always off.
 
 ---
 
@@ -63,14 +76,68 @@ What actually makes sense, and the one sentence you'd say to yourself 6 months a
 >
 > **Takeaway:** KL direction = whose "mistakes" you're punishing.
 
-**Example (batch norm):**
-> The scale and shift (γ, β) are learned per-feature. After normalising to mean=0, std=1,
-> the network *re-learns* the optimal scale for each feature. The normalisation step
-> makes the loss landscape smoother; the learnable parameters ensure you don't lose
-> representational power. They're not afterthoughts - they're what keeps the layer useful.
+**Example (watercolors):**
+> The paper goes through stages: very wet, damp, slightly damp, dry. Each stage produces
+> a different bloom behaviour. Wet-on-wet only works predictably if both the paper and
+> the brush charge are at the same moisture level. The fix was working faster and
+> re-wetting intentionally rather than assuming the paper was still wet from before.
 >
-> **Takeaway:** Batch norm's job isn't to fix the scale - it's to make the scale
-> learnable from a stable starting point.
+> **Takeaway:** Wet-on-wet is about matching moisture levels, not just "wet paper."
+
+---
+
+## Post Format 2: The Exploration
+
+For things you're curious about but haven't resolved. Three moves, different shape.
+Publish when the snapshot is interesting enough on its own - you don't need the answer first.
+An Exploration can later become a Resolution if it resolves.
+
+---
+
+### Move 1: What I'm Curious About
+
+The question or pull. Not a confusion with a wrong model - just something that has your attention.
+State it precisely: "I keep wondering whether X..." or "I can't find a clear answer on Y..."
+
+**ML example:**
+> "Emergent capabilities" gets discussed constantly but I can't find a crisp definition
+> that distinguishes genuine emergence from just "we didn't test at smaller scales."
+
+**Hobby example:**
+> Does watercolor paper weight (300gsm vs 140gsm) actually change how wet-on-wet behaves,
+> or is the only real difference whether the paper buckles?
+
+---
+
+### Move 2: What I've Found So Far
+
+Current state of understanding. Partial is fine - this is a snapshot, not a conclusion.
+What have you read, tried, or asked? What partial answers exist?
+
+**ML example:**
+> The Wei et al. (2022) paper defines emergence as a capability absent below a threshold
+> and present above it. But the Schaeffer et al. (2023) response argues the "sharpness"
+> depends entirely on metric choice - so the phenomenon might be real or a measurement artefact.
+
+**Hobby example:**
+> 140gsm buckles badly without stretching. 300gsm stays flat. But I haven't found a clear
+> answer on whether the sizing (the coating that controls absorbency) differs between weights,
+> or whether it's purely structural.
+
+---
+
+### Move 3: What I'm Still Wondering
+
+The open questions. This is the honest part: you don't have it figured out.
+Leave these genuinely open - don't fake uncertainty you've already resolved.
+
+**ML example:**
+> Whether there's a domain-agnostic way to detect emergence that doesn't depend on
+> the metric you chose to measure.
+
+**Hobby example:**
+> Whether stretching 140gsm actually replicates the paint behaviour of 300gsm,
+> or just the flatness.
 
 ---
 
@@ -78,15 +145,15 @@ What actually makes sense, and the one sentence you'd say to yourself 6 months a
 
 **Write to yourself from 6 months ago.**
 
-That version of you had your general ML/CS background but hadn't encountered *this specific thing*.
-They can handle technical language. They don't need basics re-explained.
-They do need the specific nuance explained clearly.
+That version of you had your background in this domain but hadn't encountered
+*this specific nuance*. They can handle technical or craft-specific language.
+They don't need basics re-explained. They do need the specific nuance explained clearly.
 
 | Fails the test | Passes the test |
 |---|---|
-| "Gradient descent updates weights to minimise loss" - too basic | "I assumed Adam's β₂ was just variance smoothing, but its interaction with the warmup schedule changes the effective learning rate non-linearly in the first N steps" |
-| "KL divergence measures the difference between two distributions" - too generic | "I thought both KL directions punished the same errors - just from opposite sides" |
-| A formal definition from a textbook | The specific sentence that made something click |
+| "Gradient descent updates weights to minimise loss" - too basic | "I assumed Adam's beta_2 was just variance smoothing, but its interaction with the warmup schedule changes the effective learning rate non-linearly in the first N steps" |
+| "Watercolor bleeds on wet paper" - obvious | "I thought the bloom was caused by too much paint - it was actually caused by the brush charge being wetter than the paper" |
+| A formal definition from a textbook or manual | The specific sentence that made something click |
 
 ---
 
@@ -97,8 +164,9 @@ Ask one question: **Would I have found this useful 6 months ago?**
 **High value:**
 - A concept from an OMSCS course the lecture made opaque - and you found the intuition elsewhere
 - A library or API that behaves differently from what the docs suggest
-- A result that surprised you, and why the naive expectation was wrong
+- A result in a hobby or craft that surprised you, and why the naive expectation was wrong
 - A mental model you held for months that turned out to be subtly incorrect
+- A question you keep returning to across different contexts (good Exploration candidate)
 
 **Low value:**
 - "Here's how to install X" - documentation, not insight
@@ -122,14 +190,14 @@ You're a practitioner doing grad school. That's rare. Honour both sides.
 
 ---
 
-## Notebook Posts vs. Short Posts
+## Post Formats at a Glance
 
-| | Notebook post | Short post |
-|---|---|---|
-| **Length** | Long - code + explanation | Short - 200–400 words |
-| **Source** | `notebooks/` → automation pipeline | GitHub Issues → `_posts/` directly |
-| **Best for** | Experiments, data exploration, algorithm comparisons | Conceptual confusions, mental model corrections, OMSCS insights |
-| **Rule of thumb** | The *process* matters (what you tried, what happened) | The *moment* matters (one thing that clicked) |
+| | Resolution | Exploration | Notebook |
+|---|---|---|---|
+| **Length** | 200-400 words | 200-400 words | Long - code + explanation |
+| **Source** | GitHub Issues → `_posts/` | GitHub Issues → `_posts/` | `notebooks/` → automation |
+| **Ends with** | A takeaway | Open questions | Observations + code |
+| **Trigger** | Something resolved | Something has attention | Experiment completed |
 
 ---
 
@@ -137,48 +205,46 @@ You're a practitioner doing grad school. That's rare. Honour both sides.
 
 **Don't set a cadence. Set a trigger.**
 
-The trigger is: *resolved confusion → post opportunity*.
+Two triggers, not one:
 
-With active OMSCS + MITx studying, that's naturally 1–4 short posts a month without forcing anything. A "post every week" commitment produces mediocre posts written just to hit the number. Write when something clicks. The constraint isn't time - it's having the resolution.
+- **Resolution trigger:** Something clicked. Write within 48 hours - after that, the confusion
+  feels obvious in hindsight and you lose the ability to explain it to someone still confused.
+- **Exploration trigger:** Something has your sustained attention. Publish when the snapshot
+  of where you currently are is interesting on its own.
 
-The window matters: write within 48 hours of the moment something clicks. After that, the confusion feels obvious in hindsight and you lose the ability to explain it to someone who's still confused.
+A "post every week" commitment produces mediocre posts written just to hit the number.
+The constraint for Resolutions isn't time - it's having the resolution.
+The constraint for Explorations is finding the question precise enough to be useful.
 
 ---
 
-## The Draft Workflow: GitHub Issues as Drafts
+## The Draft Workflow: GitHub Issues
 
-Short posts live entirely in GitHub Issues until publish time. You don't need a laptop until the last step.
+All short posts (Resolution and Exploration) live in GitHub Issues until publish time.
+You don't need a laptop until the last step.
 
 ```
 GitHub Issue (phone)  →  _posts/ (laptop, when ready)
 ```
 
-**Labels to use:**
+**Labels:**
 
 | Label | Meaning |
 |---|---|
-| `confusion` | Captured - the confusion exists, resolution pending |
+| `confusion` | Resolution post captured - specific confusion, resolution pending |
 | `drafting` | Moves 1 + 2 written, working on resolution |
-| `ready` | All three moves complete, ready to publish |
+| `ready` | Complete and ready to publish (either format) |
+| `exploration` | Curiosity post - publish when snapshot is interesting, no resolution needed |
 
-**The workflow:**
+**Resolution workflow:**
 
-1. **Capture (phone):** Feel confusion → open GitHub Issue → write one sentence → label `confusion`.
-   The issue title = your post's working title.
+1. **Capture (phone):** Feel confusion → open Issue → one sentence → label `confusion`
+2. **Draft:** Fill in moves 1 + 2 in the issue body. Label `drafting`. Leave move 3 blank.
+3. **Iterate:** Add comments as you think more. Edit the body as understanding evolves.
+4. **Resolve:** Fill in move 3. Label `ready`.
+5. **Publish (laptop):** Copy to `_posts/YYYY-MM-DD-slug.md`. Push to `dev`. Close issue.
 
-2. **Draft (phone or laptop):** Fill in Move 1 and Move 2 in the issue body using the template below.
-   Change label to `drafting`. Leave Move 3 blank - that's fine.
-
-3. **Iterate:** Add comments to the issue as you think more about it.
-   Edit the body as your understanding evolves.
-
-4. **Resolve:** Work through the confusion. When you have it, fill in Move 3.
-   Change label to `ready`.
-
-5. **Publish (laptop):** Copy the issue body into `_posts/YYYY-MM-DD-slug.md`.
-   Add front matter. Push to `dev`. Close the issue. Done.
-
-**Issue body template** (paste this into every new Issue):
+**Resolution issue body template:**
 
 ```markdown
 ## The Confusion
@@ -197,16 +263,40 @@ GitHub Issue (phone)  →  _posts/ (laptop, when ready)
 *Source:*
 ```
 
-**Notebook posts** still use the automation pipeline (`notebooks/` → GitHub Actions → `_posts/`).
-The `_drafts/` folder in the repo is only for notebook-related staging; short posts skip it entirely.
+**Exploration workflow:**
 
-An issue can sit open for weeks. That's fine. The goal is to **never lose a confusion**.
+1. **Capture (phone):** Notice a curiosity → open Issue → state the question precisely → label `exploration`
+2. **Build:** Add what you're finding in comments. Edit the body as the snapshot evolves.
+3. **Publish when ready:** When the snapshot is worth sharing - even without an answer.
+4. **Promote if it resolves:** If the curiosity becomes a resolved confusion, relabel `confusion` → work through moves → publish as a Resolution.
+
+**Exploration issue body template:**
+
+```markdown
+## What I'm Curious About
+
+
+## What I've Found So Far
+
+
+## What I'm Still Wondering
+
+---
+*Domain:*
+*Related to:*
+```
+
+**Notebook posts** still use the automation pipeline (`notebooks/` → GitHub Actions → `_posts/`).
+
+An issue can sit open for weeks. The goal is to **never lose a curiosity or confusion**.
 
 ---
 
 ## Tag Taxonomy
 
-Use at most 2–3 tags per post. Be consistent - these are how future-you finds things.
+Use at most 2-3 tags per post. Be consistent - these are how future-you finds things.
+
+**ML and technical:**
 
 | Tag | Use for |
 |---|---|
@@ -218,8 +308,22 @@ Use at most 2–3 tags per post. Be consistent - these are how future-you finds 
 | `implementation` | Code behaviour, library quirks, debugging |
 | `OMSCS` | Course-specific insights - pair with course code tag |
 | `paper-notes` | Insight from a specific paper |
-| `intuition` | Mental model corrections, "aha" moments |
 | `mlops` | Deployment, pipelines, experiment tracking |
+
+**Craft and hobbies:**
+
+| Tag | Use for |
+|---|---|
+| `hardware` | Arduino, electronics, physical computing |
+| `creative` | Painting, music, visual arts |
+| `craft` | Cycle maintenance, physical skills, making things |
+
+**Format:**
+
+| Tag | Use for |
+|---|---|
+| `intuition` | Mental model corrections, "aha" moments (Resolution) |
+| `exploration` | Posts using the Exploration format |
 
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Setup
 title:               Learning curve
 tagline:             'An authentic pursuit to rid the imposter in me 🧘'
-description:         'Logging Curiosities and Experiments with ML Tools & Techniques: A Recording of My Learnings. <br><i>Attempting a Feynman here!</i><br> Journal blog by <a href="https://twitter.com/nishzsche" target="_blank">@nishzsche</a>'
+description:         'A learning journal. Figuring things out - ML, OMSCS, hobbies, whatever currently has attention. Feynman-ish: if I cannot explain it clearly, I probably do not understand it yet. By <a href="https://twitter.com/nishzsche" target="_blank">@nishzsche</a>'
 url:                 https://nishzsche.github.io
 baseurl:             ''
 paginate:            5

--- a/_drafts/_exploration_template.md
+++ b/_drafts/_exploration_template.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: ""
+date: YYYY-MM-DD
+tags: [exploration]
+---
+
+## What I'm Curious About
+
+<!-- The question or pull - not a resolved confusion, just something that has your attention.
+     State it precisely: "I keep wondering whether X..." or "I can't find a clear answer on Y..."
+     The more specific the question, the more useful the post. -->
+
+## What I've Found So Far
+
+<!-- Current state of understanding. Partial is fine - this is a snapshot, not a conclusion.
+     What have you read, tried, or asked? What partial answers exist?
+     Be honest about the gaps. -->
+
+## What I'm Still Wondering
+
+<!-- The open questions. This is the honest part: you don't have it figured out.
+     Leave these genuinely open - don't fake uncertainty you've already resolved.
+     These are what make the post worth reading. -->
+
+---
+
+*Domain: [ML / OMSCS / hardware / creative / craft / other]*
+*Source so far: [what you've read, tried, or who you've asked]*

--- a/about.md
+++ b/about.md
@@ -13,7 +13,7 @@ I'm Nishanth. I've spent a decade building ML systems in fintech, operations, co
 
 Short posts about things that confused me and how I eventually resolved them, or about things I'm intrigued by. Occasionally longer posts walking through experiments and implementations from notebooks.
 
-Most things are ML-adjacent: probability, optimization, neural architectures, MLOps patterns, and whatever I'm currently working through in my OMSCS coursework or just at work.
+ML, OMSCS coursework, hardware tinkering, and whatever else currently has my attention - watercolors, cycle mechanics, guitar. The domain doesn't matter much. The learning posture does.
 
 The approach is Feynman-ish: if I can't explain it clearly, I probably don't understand it yet.
 


### PR DESCRIPTION
Scope:
- Blog is now a general learning journal, not ML-only
- about.md: "What I write here" updated to include hardware, watercolors, cycle mechanics, guitar - "The domain doesn't matter much. The learning posture does."
- _config.yml description: replaced ML-specific wording with domain-agnostic framing

WRITING.md - major restructure:
- Add summary table at top: two formats side by side (Resolution vs Exploration)
- Rename "The Three Moves" to "Post Format 1: The Resolution" - add hobby examples (watercolors wet-on-wet) alongside the existing ML examples (KL divergence)
- Add "Post Format 2: The Exploration" section with its own three moves: What I'm Curious About / What I've Found So Far / What I'm Still Wondering Annotated ML and hobby examples for each move
- Update Level Test: domain-agnostic ("your background in this domain") Add hobby row to the pass/fail table
- Update "What Makes Something Worth Posting": add hobby/craft and recurring curiosity as high-value triggers
- Add `exploration` label to GitHub Issues workflow table
- Add Exploration issue body template alongside existing Resolution template
- Add Exploration workflow (capture → build → publish → promote if resolved)
- Rename post format comparison table; add Exploration as third column
- Update Posting Frequency: two triggers (resolution click vs sustained curiosity)
- Expand Tag Taxonomy: add hardware, creative, craft, exploration tags

New file:
- _drafts/_exploration_template.md: three-section template with inline prompts for Exploration posts; includes domain and source fields in footer